### PR TITLE
bugfix(packaging): package with correct language versions

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -8,7 +8,7 @@ targets:
   ubuntu-14.04:
   debian-8:
 before:
-  - echo "runtime_path=/opt/queueflex" > elixir_buildpack.config
+  - echo "runtime_path=/opt/queueflex" >> elixir_buildpack.config
 after:
   - rm -rf .git
   - mkdir -p ../../home/queueflex


### PR DESCRIPTION
We were previously overwriting all statically defined settings when configuring the buildpack for OS package installation paths.